### PR TITLE
Update image to build with Qt 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,35 +61,43 @@ RUN apt install -y \
     libx11-dev \
     libxerces-c-dev \
     libyaml-cpp-dev \
-    libzipios++-dev 
+    libzipios++-dev
 
-# Python 3 and Qt5
-RUN apt install -y \
-    libpyside2-dev \
-    libqt5opengl5-dev \
-    libqt5svg5-dev \
-    libqt5x11extras5-dev \
-    libqt5xmlpatterns5-dev \
-    libshiboken2-dev \
-    pyqt5-dev-tools \
-    pyside2-tools \
-    python3-dev \
-    python3-matplotlib \
-    python3-packaging \
-    python3-pivy \
-    python3-ply \
-    python3-pyside2.qtcore \
-    python3-pyside2.qtgui \
-    python3-pyside2.qtnetwork \
-    python3-pyside2.qtsvg \
-    python3-pyside2.qtwebchannel \
-    python3-pyside2.qtwebengine \
-    python3-pyside2.qtwebenginecore \
-    python3-pyside2.qtwebenginewidgets \
-    python3-pyside2.qtwidgets \
-    qtbase5-dev \
-    qttools5-dev \
-    qtwebengine5-dev
+# Python 3 and Qt6
+#RUN apt install -y \
+#    libpyside2-dev \
+#    libqt6opengl6-dev \
+#    libqt6svg6-dev \
+#    libqt6x11extras6-dev \
+#    libqt6xmlpatterns6-dev \
+#    libshiboken2-dev \
+#    pyqt6-dev-tools \
+#    pyside2-tools \
+#    python3-dev \
+#    python3-matplotlib \
+#    python3-packaging \
+#    python3-pivy python3-pybind11 \
+#    python3-ply \
+#    python3-pyside2.qtcore \
+#    python3-pyside2.qtgui \
+#    python3-pyside2.qtnetwork \
+#    python3-pyside2.qtsvg \
+#    python3-pyside2.qtwebchannel \
+#    python3-pyside2.qtwebengine \
+#    python3-pyside2.qtwebenginecore \
+#    python3-pyside2.qtwebenginewidgets \
+#    python3-pyside2.qtwidgets \
+#    qtbase6-dev \
+#    qt6-tools-dev \
+#    qt6-webengine-dev
+
+
+
+RUN apt install -y libqt6opengl6-dev libqt6svg6-dev libshiboken2-dev \
+    qt6-base-dev qt6-tools-dev \
+    python3-dev python3-matplotlib python3-packaging python3-pivy \
+    python3-pybind11 python3-ply \
+    qt6-webengine-dev qt6-l10n-tools qt6-tools-dev-tools
 
 # OpenCascade
 RUN apt install -y libocct*-dev occt-draw
@@ -108,7 +116,16 @@ RUN apt install -y \
     python3-pip
 
 # Known python dependencies
-RUN python3 -m pip install ifcopenshell==0.8.0 
+RUN python3 -m pip install ifcopenshell==0.8.0
+
+WORKDIR /root
+RUN python3 -m pip install pyside6
+# build pyside, based on instrctions from https://pypi.org/project/PySide6/
+#RUN git clone https://code.qt.io/pyside/pyside-setup && \
+#    cd pyside-setup && \
+#    # if a specific version is needed
+#    git checkout 6.9 &&\
+#    python3 setup.py install --qtpaths=/usr/local/bin --build-tests
 
 # DEBUG C++ with gdb
 RUN apt install -y gdb libcanberra-gtk-module libcanberra-gtk3-module
@@ -123,7 +140,7 @@ ENV FREECAD_WINPDB_PORT=51000
 ENV FREECAD_WINPDB_PWD=1234
 EXPOSE 51000
 
-# These environment variable are set here to be used 
+# These environment variable are set here to be used
 #   by the different container's scripts
 ENV FREECAD_CONFIG_DIR="/root/.local/FreeCAD"
 ENV FREECAD_BUILD_DIR="/mnt/build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:plucky
 
 ENV FREECAD_VERSION="FreeCAD-1-0"
 
@@ -10,30 +10,15 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /tmp
 
-# REF: https://wiki.freecad.org/Compile_on_Linux
-
-# #!/bin/sh
-# sudo add-apt-repository --enable-source ppa:freecad-maintainers/freecad-daily && sudo apt-get update
-# sudo apt-get build-dep freecad-daily
-# sudo apt-get install freecad-daily
-
-# git clone --recurse-submodules https://github.com/FreeCAD/FreeCAD.git freecad-source
-# mkdir freecad-build
-# cd freecad-build
-# cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DFREECAD_USE_PYBIND11=ON ../freecad-source
-# make -j$(nproc --ignore=2)
-
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LOCALE="C.UTF-8"
 
 # Build tools, and misc supporting tools
 RUN apt update && \
-    apt install -y build-essential cmake libtool lsb-release git
-
-# Python3
-RUN apt install -y python3 swig
-
-# Boost libraries
-RUN apt install -y \
+    apt install -y build-essential cmake libtool lsb-release git \
+    # Python3
+    python3 swig \
+    # Boost libraries
     libboost-dev \
     libboost-date-time-dev \
     libboost-filesystem-dev \
@@ -43,13 +28,10 @@ RUN apt install -y \
     libboost-python-dev \
     libboost-regex-dev \
     libboost-serialization-dev \
-    libboost-thread-dev
-
-# Coin libraries
-RUN apt install -y libcoin-dev libcoin-doc libcoin-runtime
-
-# Misc libraries
-RUN apt install -y \
+    libboost-thread-dev \
+    # Coin libraries
+    libcoin-dev libcoin-doc libcoin-runtime \
+    # Misc libraries
     libeigen3-dev \
     libgts-bin \
     libgts-dev \
@@ -61,81 +43,41 @@ RUN apt install -y \
     libx11-dev \
     libxerces-c-dev \
     libyaml-cpp-dev \
-    libzipios++-dev
-
-# Python 3 and Qt6
-#RUN apt install -y \
-#    libpyside2-dev \
-#    libqt6opengl6-dev \
-#    libqt6svg6-dev \
-#    libqt6x11extras6-dev \
-#    libqt6xmlpatterns6-dev \
-#    libshiboken2-dev \
-#    pyqt6-dev-tools \
-#    pyside2-tools \
-#    python3-dev \
-#    python3-matplotlib \
-#    python3-packaging \
-#    python3-pivy python3-pybind11 \
-#    python3-ply \
-#    python3-pyside2.qtcore \
-#    python3-pyside2.qtgui \
-#    python3-pyside2.qtnetwork \
-#    python3-pyside2.qtsvg \
-#    python3-pyside2.qtwebchannel \
-#    python3-pyside2.qtwebengine \
-#    python3-pyside2.qtwebenginecore \
-#    python3-pyside2.qtwebenginewidgets \
-#    python3-pyside2.qtwidgets \
-#    qtbase6-dev \
-#    qt6-tools-dev \
-#    qt6-webengine-dev
-
-
-
-RUN apt install -y libqt6opengl6-dev libqt6svg6-dev libshiboken2-dev \
+    libzipios++-dev \
+    # Python 3 and Qt6
+    libpyside6-py3-6.8 libqt6opengl6-dev \
+    libshiboken2-dev \
+    python3-pyside6.qtcore python3-pyside6.qtgui python3-pyside6.qtnetwork \
+    python3-pyside6.qtsvg python3-pyside6.qtwebchannel \
+    python3-pyside6.qtwebenginequick python3-pyside6.qtwebenginecore \
+    python3-pyside6.qtwebenginewidgets python3-pyside6.qtwidgets \
+    python3-pyside6.qtuitools libpyside6-dev \
+    libqt6opengl6-dev libqt6svg6-dev libshiboken2-dev \
     qt6-base-dev qt6-tools-dev \
     python3-dev python3-matplotlib python3-packaging python3-pivy \
     python3-pybind11 python3-ply \
-    qt6-webengine-dev qt6-l10n-tools qt6-tools-dev-tools
-
-# OpenCascade
-RUN apt install -y libocct*-dev occt-draw
-
-# Optional packges
-RUN apt install -y \
-    checkinstall \
-    doxygen \
-    graphviz \
-    libsimage-dev \
-    libspnav-dev
-
-# To fix compilation problems
-RUN apt install -y \
-    libhdf5-openmpi-dev \
-    python3-pip
+    qt6-webengine-dev qt6-l10n-tools qt6-tools-dev-tools \
+    # OpenCascade
+    libocct*-dev occt-draw \
+    # Optional packges
+    checkinstall doxygen graphviz libsimage-dev libspnav-dev \
+    # To fix compilation problems
+    libhdf5-openmpi-dev python3-pip
 
 # Known python dependencies
-RUN python3 -m pip install ifcopenshell==0.8.0
-
-WORKDIR /root
-RUN python3 -m pip install pyside6
-# build pyside, based on instrctions from https://pypi.org/project/PySide6/
-#RUN git clone https://code.qt.io/pyside/pyside-setup && \
-#    cd pyside-setup && \
-#    # if a specific version is needed
-#    git checkout 6.9 &&\
-#    python3 setup.py install --qtpaths=/usr/local/bin --build-tests
+# RUN python3 -m pip install --break-system-packages ifcopenshell
 
 # DEBUG C++ with gdb
-RUN apt install -y gdb libcanberra-gtk-module libcanberra-gtk3-module
-RUN python3 -m pip install gdbgui
+RUN apt install -y gdb
+# libcanberra-gtk-module libcanberra-gtk3-module
+# greenlet dependency can not be compiled
+# RUN python3 -m pip install --break-system-packages gdbgui
 ENV FREECAD_GDB_PORT=5000
 EXPOSE 5000
 
 # DEBUG Python with winpdb
 RUN apt install -y wxpython-tools
-RUN python3 -m pip install winpdb-reborn
+RUN python3 -m pip install --break-system-packages winpdb-reborn
 ENV FREECAD_WINPDB_PORT=51000
 ENV FREECAD_WINPDB_PWD=1234
 EXPOSE 51000

--- a/README.md
+++ b/README.md
@@ -15,7 +15,22 @@ The docker is not deployed and therefore you need to build it locally
 
 ## Build the docker image
 
-You must edit the [run_docker.sh](run_docker.sh) to set the correct path to the `SOURCE_DIR`, `BUILD_DIR` and `CONF_DIR`. Then you can execute `run_docker.sh`:
+Before running `run_docker.sh` you need to define the directories for the sources and the build result.
+
+One option is create a file `env.sh` with the following variables
+```
+SOURCE_DIR=~/proyectos/freecad_source
+BUILD_DIR=~/proyectos/freecad_build
+CONF_DIR=~/.config/FreeCAD
+```
+
+Other option is use parameters to configure the directories
+
+```shell
+?> ./run_docker.sh --source-dir ~/sources/freecad_source --build-dir ~/freecad_build --config-dif ~/.config/FreeCAD
+```
+
+If you have the `env.sh` file created, just run
 
 ```shell
 ?> ./run_docker.sh
@@ -25,8 +40,9 @@ You must edit the [run_docker.sh](run_docker.sh) to set the correct path to the 
 
 Once the docker container has been created, you should have access to a command prompt that allows you to build your version of FreeCAD.
 
+
 ```shell
-docker> /root/build_freecad.sh
+docker> /root/build_FC.sh
 ```
 
 ## Run FreeCAD
@@ -53,6 +69,8 @@ You will be able to find the mounted directories within the container in the
 REF: [Python workbenches debugging](https://forum.freecad.org/viewtopic.php?t=35383)
 
 * Start winpdb
+
+(This is not working right now)
 
 ```shell
 docker> winpdb

--- a/add_files/build_FC.sh
+++ b/add_files/build_FC.sh
@@ -62,8 +62,8 @@ set -e
 # NOTE: The PYTHON_LIBRARY is dependant on the base image used
 #   in the docker file.
 cmake \
-    -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0 \
-    -D PYTHON_INCLUDE_DIR=/usr/include/python3.10/ \
+    -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.13.so.1.0 \
+    -D PYTHON_INCLUDE_DIR=/usr/include/python3.13/ \
     -D PYTHON_EXECUTABLE=/usr/bin/python3 \
     -D FREECAD_USE_OCC_VARIANT="Official Version" \
     -D BUILD_QT6=ON \

--- a/add_files/build_FC.sh
+++ b/add_files/build_FC.sh
@@ -41,7 +41,7 @@ EOF
 #==============================================================================
 options=$(getopt --alternative --name $(basename $0) --options "hdr" --longoptions help,debug,release -- $0 "$@")
 if [ $? -ne 0 ]; then
-    usage 
+    usage
     exit 1
 fi
 eval set -- "$options"
@@ -66,10 +66,15 @@ cmake \
     -D PYTHON_INCLUDE_DIR=/usr/include/python3.10/ \
     -D PYTHON_EXECUTABLE=/usr/bin/python3 \
     -D FREECAD_USE_OCC_VARIANT="Official Version" \
-    -D BUILD_QT5=ON \
+    -D BUILD_QT6=ON \
     -D BUILD_FEM=ON \
     -D BUILD_SANDBOX=OFF \
     -D BUILD_DESIGNER_PLUGIN=ON \
+    -D FREECAD_QT_MAJOR_VERSION=6 \
+    -D FREECAD_QT_VERSION=6 \
+    -D ENABLE_DEVELOPER_TESTS=Off \
+    -D Boost_USE_DEBUG_RUNTIME=FALSE \
+    -D FREECAD_USE_PCL=Off \
     -D CMAKE_BUILD_TYPE=$p_build_type \
     -S ${FREECAD_SOURCE_DIR} \
     -B ${FREECAD_BUILD_DIR}

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -8,10 +8,22 @@
 # REF: https://wiki.freecad.org/Compile_on_Docker
 
 
-p_source_dir=~/proyectos/freecad_source
-p_build_dir=~/proyectos/freecad_build
+p_source_dir=~/git/opensource/FreeCAD
+p_build_dir=~/git/opensource/FreeCAD-build
 p_conf_dir=~/.config/FreeCAD
 HOME_DIR=~/
+
+# try to read directories from "env.sh" file
+source env.sh
+if [ ! -z "${SOURCE_DIR}" ]; then
+    p_source_dir=${SOURCE_DIR}
+fi
+if [ ! -z "${BUILD_DIR}" ]; then
+    p_build_dir=${BUILD_DIR}
+fi
+if [ ! -z "${CONF_DIR}" ]; then
+    p_conf_dir=${CONF_DIR}
+fi
 
 #------------------------------------------------------------------------------
 # FUNCTION: usage
@@ -80,6 +92,10 @@ if [ ! -d "${p_source_dir}" ]; then
   echo "Invalid '--source-dir'. No such file or directory" >&2
   exit 1
 fi
+
+echo "Reading freecad sources from ${p_source_dir}"
+echo "Building to ${p_build_dir}"
+echo "Freecad preferencies from ${p_conf_dir}"
 
 echo "Building docker container ..."
 

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -8,8 +8,8 @@
 # REF: https://wiki.freecad.org/Compile_on_Docker
 
 
-p_source_dir=~/git/opensource/FreeCAD
-p_build_dir=~/git/opensource/FreeCAD-build
+p_source_dir=~/proyectos/freecad_source
+p_build_dir=~/proyectos/freecad_build
 p_conf_dir=~/.config/FreeCAD
 HOME_DIR=~/
 
@@ -48,7 +48,7 @@ EOF
 #==============================================================================
 options=$(getopt --alternative --name $(basename $0) --options "hc:b:s:" --longoptions help,config-dir:,build-dir:,source-dir: -- $0 "$@")
 if [ $? -ne 0 ]; then
-    usage 
+    usage
     exit 1
 fi
 eval set -- "$options"


### PR DESCRIPTION
This pr updates the Dockerfile and scripts to allow build FreeCAD with Qt 6

For this I needed use a newer version of Ubuntu as a base (pluncky)

Sadly, the gdbgui doesnot install anymore, neither winpdb

I also added the posibility of use a file "env.sh" to configure the directories, so is not needed anymore to edit run_docker.sh